### PR TITLE
Responses are a union of possible operations response types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -54,7 +54,9 @@ type OpResponseTypes<OP> = OP extends {
   responses: infer R
 }
   ? {
-      [S in keyof R]: R[S] extends { schema?: infer S } // openapi 2
+      [S in keyof R]: R[S] extends never
+        ? undefined
+        : R[S] extends { schema?: infer S } // openapi 2
         ? S
         : R[S] extends JSONBody<infer C> // openapi 3
         ? C
@@ -64,15 +66,7 @@ type OpResponseTypes<OP> = OP extends {
     }
   : never
 
-type _OpReturnType<T> = 200 extends keyof T
-  ? T[200]
-  : 201 extends keyof T
-  ? T[201]
-  : 202 extends keyof T
-  ? T[202]
-  : 'default' extends keyof T
-  ? T['default']
-  : unknown
+type _OpReturnType<T> = keyof T extends number | 'default' ? T[keyof T] : never
 
 export type OpReturnType<OP> = _OpReturnType<OpResponseTypes<OP>>
 

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -112,14 +112,14 @@ describe('fetch', () => {
   })
 
   it(`POST /accepted`, async () => {
-    const fun = fetcher.path('/accepted').method('post').create()
+    const fun = fetcher.path('/accepted').method('post').create({})
     const { status, data } = await fun(undefined)
     expect(status).toBe(202)
     expect(data.message).toBe('Accepted')
   })
 
   it(`POST /nocontent`, async () => {
-    const fun = fetcher.path('/nocontent').method('post').create()
+    const fun = fetcher.path('/nocontent').method('post').create({})
     const { status, data } = await fun(undefined)
     expect(status).toBe(204)
     expect(data).toBeUndefined()

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -120,9 +120,15 @@ describe('fetch', () => {
 
   it(`POST /nocontent`, async () => {
     const fun = fetcher.path('/nocontent').method('post').create({})
-    const { status, data } = await fun(undefined)
+    const response = await fun(undefined)
+    const { status, data } = response
+    // if (response.status === 200) {
+    //   response.data.message
+    // }
     expect(status).toBe(204)
     expect(data).toBeUndefined()
+    expect(data).toEqual(undefined)
+    assertType<{ message: string } | undefined>()(data)
   })
 
   it('GET /error', async () => {

--- a/test/infer.test.ts
+++ b/test/infer.test.ts
@@ -71,6 +71,8 @@ describe('infer', () => {
     expect(same).toBe(true)
 
     const ret: Openapi2['Return'] = {} as any
+    // url is does not exist on the error case
+    // the status code should descriminate the type
     expect(ret.url).toBeUndefined()
   })
 

--- a/test/paths.ts
+++ b/test/paths.ts
@@ -73,7 +73,8 @@ export type paths = {
     post: {
       parameters: {}
       responses: {
-        204: unknown
+        200: { schema: { message: string } }
+        204: never
       }
     }
   }

--- a/test/util.d.ts
+++ b/test/util.d.ts
@@ -1,0 +1,3 @@
+declare const assertType: <T>() => <U extends T>(
+  result: [T] extends [U] ? U : never,
+) => void


### PR DESCRIPTION
Currently the data property of a response is based on the type of one success responses. This is incorrect, because different status codes may return different response types.

This is a breaking change, since working code may now cause compile errors, requiring you to narrow the type before you can use it.

Fixes #2 