### PR TITLE
Temporarily pack json-with-bigint locally until this package supports CJS modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @qdrant/openapi-typescript-fetch
 
+## 1.2.3
+
+### Patch Changes
+
+- Temporarily pack json-with-bigint locally until this package supports CJS modules
+
 ## 1.2.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -118,8 +118,5 @@
     "tsc:check": "tsc --noEmit",
     "ci:version": "pnpm changeset version && pnpm install --no-frozen-lockfile && git add .",
     "ci:release": "pnpm changeset publish"
-  },
-  "dependencies": {
-    "json-with-bigint": "^2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qdrant/openapi-typescript-fetch",
   "description": "A typed fetch client for openapi-typescript",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "engines": {
     "node": ">=12.0.0",
     "pnpm": ">=8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,11 +11,6 @@ overrides:
   word-wrap: 1.2.4
   graphql: ' 16.8.1 '
 
-dependencies:
-  json-with-bigint:
-    specifier: ^2.1.0
-    version: 2.1.0
-
 devDependencies:
   '@changesets/changelog-github':
     specifier: 0.4.8
@@ -3690,10 +3685,6 @@ packages:
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
-
-  /json-with-bigint@2.1.0:
-    resolution: {integrity: sha512-YPzGFHUMINmXqw4iK1pRPDp71nRaxXtoGenmGycRVCOcp47nMkgbrJwT0dYjeHeLzS+knsWlJo7x5F4kEIf5Fg==}
-    dev: false
 
   /json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -14,7 +14,7 @@ import {
   _TypedFetch,
   TypedFetch,
 } from './types.js'
-import { JSONParse, JSONStringify } from 'json-with-bigint'
+import { JSONParse, JSONStringify } from './json-with-bigint.js'
 
 const sendBody = (method: Method) =>
   method === 'post' ||

--- a/src/json-with-bigint.ts
+++ b/src/json-with-bigint.ts
@@ -1,0 +1,81 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2023 Ivan Korolenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+type JsonArray = Array<Json>
+
+export type Json =
+  | null
+  | undefined
+  | string
+  | number
+  | bigint
+  | boolean
+  | JsonObject
+  | Record<string, unknown>
+  | JsonArray
+
+interface JsonObject {
+  [x: string]: Json
+}
+
+/* 
+  Function to serialize data to JSON string
+  Converts BigInt values to custom format (strings with digits and "n" at the end) and then converts them to proper big integers in JSON string
+*/
+export const JSONStringify = (data: Json): string => {
+  const bigInts = /([\[:])?"(\d+)n"([,\}\]])/g
+  const preliminaryJSON = JSON.stringify(data, (_, value) =>
+    typeof value === 'bigint' ? value.toString() + 'n' : value,
+  )
+  const finalJSON = preliminaryJSON.replace(bigInts, '$1$2$3')
+
+  return finalJSON
+}
+
+/* 
+  Function to parse JSON
+  If JSON has values presented in a lib's custom format (strings with digits and "n" character at the end), we just parse them to BigInt values (for backward compatibility with previous versions of the lib)
+  If JSON has values greater than Number.MAX_SAFE_INTEGER, we convert those values to our custom format, then parse them to BigInt values.
+  Other types of values are not affected and parsed as native JSON.parse() would parse them.
+
+  Big numbers are found and marked using RegEx with these conditions:
+    - Before the match there's : OR :[ OR :[anyNumberOf(anyCharacters)
+    - The match itself has more than 16 digits OR (16 digits and any digit of the number is greater than that of the Number.MAX_SAFE_INTEGER)
+    - After the match there's , OR } OR ]
+*/
+export function JSONParse<T extends Json = Json>(json: string): T {
+  const numbersBiggerThanMaxInt =
+    /(?<=:|:\[|:\[.*)(\d{17,}|(?:[9](?:[1-9]07199254740991|0[1-9]7199254740991|00[8-9]199254740991|007[2-9]99254740991|007199[3-9]54740991|0071992[6-9]4740991|00719925[5-9]740991|007199254[8-9]40991|0071992547[5-9]0991|00719925474[1-9]991|00719925474099[2-9])))(?=[,\}\]])/g
+  const serializedData = json.replace(numbersBiggerThanMaxInt, '"$1n"')
+
+  return JSON.parse(serializedData, (_, value) => {
+    const isCustomFormatBigInt =
+      typeof value === 'string' && value.match(/^\d+n$/)
+
+    if (isCustomFormatBigInt)
+      return BigInt(value.substring(0, value.length - 1))
+
+    return value
+  })
+}


### PR DESCRIPTION
`json-with-bigint` [does not support CJS](https://github.com/Ivan-Korolenko/json-with-bigint/blob/main/package.json#L5), and this led to issues for users of the our JS SDK loading CJS in Node:

https://discord.com/channels/907569970500743200/1209507491746942976/1209507491746942976

We'll add support for ESM ourselves. In the meantime, this packs the dependency locally, since rolling back also introduces regressions in the GH workflows and vulnerability issues that got resolved when we merged the PR previously.