### PR TITLE
Fix/merino/big int node 18 test compat

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [21]
+        node-version: [18, 20, 21]
         os:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [21]
+        node-version: [18]
     steps:
       - uses: actions/checkout@v3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @qdrant/openapi-typescript-fetch
 
+## 1.2.5
+
+### Patch Changes
+
+- Return to Node.js 18 compatibility and skip BigInt support and test until Node 21
+
 ## 1.2.4
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qdrant/openapi-typescript-fetch",
   "description": "A typed fetch client for openapi-typescript",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "engines": {
     "node": ">=18.0.0",
     "pnpm": ">=8"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A typed fetch client for openapi-typescript",
   "version": "1.2.4",
   "engines": {
-    "node": ">=21.0.0",
+    "node": ">=18.0.0",
     "pnpm": ">=8"
   },
   "packageManager": "pnpm@8.5.0",
@@ -77,6 +77,8 @@
     "@changesets/changelog-github": "0.4.8",
     "@changesets/cli": "2.26.1",
     "@types/jest": "^29.5.12",
+    "@types/node": "^18.0.0",
+    "@types/semver": "^7.5.7",
     "@typescript-eslint/eslint-plugin": "^4.30.0",
     "@typescript-eslint/parser": "^4.31.0",
     "codecov": "^3.8.2",
@@ -88,6 +90,7 @@
     "msw": "^0.49.3",
     "prettier": "^2.4.0",
     "rimraf": "^3.0.0",
+    "semver": "^7.6.0",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
     "typescript": ">=4.7",
@@ -101,10 +104,10 @@
   "pnpm": {
     "overrides": {
       "@babel/traverse": "7.23.2",
-      "semver": "7.5.2",
+      "graphql": "16.8.1",
+      "semver": "7.6.0",
       "tough-cookie": "4.1.3",
-      "word-wrap": "1.2.4",
-      "graphql": " 16.8.1 "
+      "word-wrap": "1.2.4"
     }
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,10 +6,10 @@ settings:
 
 overrides:
   '@babel/traverse': 7.23.2
-  semver: 7.5.2
+  graphql: 16.8.1
+  semver: 7.6.0
   tough-cookie: 4.1.3
   word-wrap: 1.2.4
-  graphql: ' 16.8.1 '
 
 devDependencies:
   '@changesets/changelog-github':
@@ -21,6 +21,12 @@ devDependencies:
   '@types/jest':
     specifier: ^29.5.12
     version: 29.5.12
+  '@types/node':
+    specifier: ^18.0.0
+    version: 18.0.0
+  '@types/semver':
+    specifier: ^7.5.7
+    version: 7.5.7
   '@typescript-eslint/eslint-plugin':
     specifier: ^4.30.0
     version: 4.30.0(@typescript-eslint/parser@4.31.0)(eslint@7.32.0)(typescript@4.7.2)
@@ -41,7 +47,7 @@ devDependencies:
     version: 4.0.0(eslint-config-prettier@8.3.0)(eslint@7.32.0)(prettier@2.4.0)
   jest:
     specifier: ^29.7.0
-    version: 29.7.0(@types/node@20.1.2)(ts-node@10.9.2)
+    version: 29.7.0(@types/node@18.0.0)(ts-node@10.9.2)
   jest-environment-jsdom:
     specifier: ^29.7.0
     version: 29.7.0
@@ -54,12 +60,15 @@ devDependencies:
   rimraf:
     specifier: ^3.0.0
     version: 3.0.0
+  semver:
+    specifier: 7.6.0
+    version: 7.6.0
   ts-jest:
     specifier: ^29.1.2
     version: 29.1.2(@babel/core@7.21.8)(jest@29.7.0)(typescript@4.7.2)
   ts-node:
     specifier: ^10.9.2
-    version: 10.9.2(@types/node@20.1.2)(typescript@4.7.2)
+    version: 10.9.2(@types/node@18.0.0)(typescript@4.7.2)
   typescript:
     specifier: '>=4.7'
     version: 4.7.2
@@ -126,7 +135,7 @@ packages:
       debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 7.5.2
+      semver: 7.6.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -149,7 +158,7 @@ packages:
       debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 7.5.2
+      semver: 7.6.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -175,7 +184,7 @@ packages:
       '@babel/helper-validator-option': 7.21.0
       browserslist: 4.21.5
       lru-cache: 5.1.1
-      semver: 7.5.2
+      semver: 7.6.0
     dev: true
 
   /@babel/helper-compilation-targets@7.23.6:
@@ -186,7 +195,7 @@ packages:
       '@babel/helper-validator-option': 7.23.5
       browserslist: 4.23.0
       lru-cache: 5.1.1
-      semver: 7.5.2
+      semver: 7.6.0
     dev: true
 
   /@babel/helper-environment-visitor@7.22.20:
@@ -574,7 +583,7 @@ packages:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.5.2
+      semver: 7.6.0
     dev: true
 
   /@changesets/assemble-release-plan@5.2.3:
@@ -585,7 +594,7 @@ packages:
       '@changesets/get-dependents-graph': 1.3.5
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
-      semver: 7.5.2
+      semver: 7.6.0
     dev: true
 
   /@changesets/changelog-git@0.1.14:
@@ -637,7 +646,7 @@ packages:
       p-limit: 2.3.0
       preferred-pm: 3.0.3
       resolve-from: 5.0.0
-      semver: 7.5.2
+      semver: 7.6.0
       spawndamnit: 2.0.0
       term-size: 2.2.1
       tty-table: 4.2.1
@@ -668,7 +677,7 @@ packages:
       '@manypkg/get-packages': 1.1.3
       chalk: 2.4.2
       fs-extra: 7.0.1
-      semver: 7.5.2
+      semver: 7.6.0
     dev: true
 
   /@changesets/get-github-info@0.5.2:
@@ -822,7 +831,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -843,14 +852,14 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.8.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.1.2)(ts-node@10.9.2)
+      jest-config: 29.7.0(@types/node@18.0.0)(ts-node@10.9.2)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -878,7 +887,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
       jest-mock: 29.7.0
     dev: true
 
@@ -905,7 +914,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -938,7 +947,7 @@ packages:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.18
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -1026,7 +1035,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
       '@types/yargs': 17.0.24
       chalk: 4.1.2
     dev: true
@@ -1225,7 +1234,7 @@ packages:
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
     dev: true
 
   /@types/is-ci@3.0.0:
@@ -1264,7 +1273,7 @@ packages:
   /@types/jsdom@20.0.1:
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
     dependencies:
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
       '@types/tough-cookie': 4.0.2
       parse5: 7.1.2
     dev: true
@@ -1285,8 +1294,8 @@ packages:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
 
-  /@types/node@20.1.2:
-    resolution: {integrity: sha512-CTO/wa8x+rZU626cL2BlbCDzydgnFNgc19h4YvizpTO88MFQxab8wqisxaofQJ/9bLGugRdWIuX/TbIs6VVF6g==}
+  /@types/node@18.0.0:
+    resolution: {integrity: sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==}
     dev: true
 
   /@types/normalize-package-data@2.4.1:
@@ -1297,10 +1306,14 @@ packages:
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
     dev: true
 
+  /@types/semver@7.5.7:
+    resolution: {integrity: sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg==}
+    dev: true
+
   /@types/set-cookie-parser@2.4.2:
     resolution: {integrity: sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==}
     dependencies:
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
     dev: true
 
   /@types/stack-utils@2.0.1:
@@ -1339,7 +1352,7 @@ packages:
       eslint: 7.32.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.2.0
-      semver: 7.5.2
+      semver: 7.6.0
       tsutils: 3.21.0(typescript@4.7.2)
       typescript: 4.7.2
     transitivePeerDependencies:
@@ -1424,7 +1437,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.2
+      semver: 7.6.0
       tsutils: 3.21.0(typescript@4.7.2)
       typescript: 4.7.2
     transitivePeerDependencies:
@@ -1445,7 +1458,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.2
+      semver: 7.6.0
       tsutils: 3.21.0(typescript@4.7.2)
       typescript: 4.7.2
     transitivePeerDependencies:
@@ -2015,7 +2028,7 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
-  /create-jest@29.7.0(@types/node@20.1.2)(ts-node@10.9.2):
+  /create-jest@29.7.0(@types/node@18.0.0)(ts-node@10.9.2):
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -2024,7 +2037,7 @@ packages:
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.1.2)(ts-node@10.9.2)
+      jest-config: 29.7.0(@types/node@18.0.0)(ts-node@10.9.2)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -2450,7 +2463,7 @@ packages:
       optionator: 0.9.1
       progress: 2.0.3
       regexpp: 3.2.0
-      semver: 7.5.2
+      semver: 7.6.0
       strip-ansi: 6.0.1
       strip-json-comments: 3.1.1
       table: 6.8.1
@@ -3244,7 +3257,7 @@ packages:
       '@babel/parser': 7.23.6
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
-      semver: 7.5.2
+      semver: 7.6.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3257,7 +3270,7 @@ packages:
       '@babel/parser': 7.23.9
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
-      semver: 7.5.2
+      semver: 7.6.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3307,7 +3320,7 @@ packages:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.1
@@ -3328,7 +3341,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli@29.7.0(@types/node@20.1.2)(ts-node@10.9.2):
+  /jest-cli@29.7.0(@types/node@18.0.0)(ts-node@10.9.2):
     resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -3342,10 +3355,10 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.1.2)(ts-node@10.9.2)
+      create-jest: 29.7.0(@types/node@18.0.0)(ts-node@10.9.2)
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.1.2)(ts-node@10.9.2)
+      jest-config: 29.7.0(@types/node@18.0.0)(ts-node@10.9.2)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -3356,7 +3369,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config@29.7.0(@types/node@20.1.2)(ts-node@10.9.2):
+  /jest-config@29.7.0(@types/node@18.0.0)(ts-node@10.9.2):
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -3371,7 +3384,7 @@ packages:
       '@babel/core': 7.21.8
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
       babel-jest: 29.7.0(@babel/core@7.21.8)
       chalk: 4.1.2
       ci-info: 3.8.0
@@ -3391,7 +3404,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.2(@types/node@20.1.2)(typescript@4.7.2)
+      ts-node: 10.9.2(@types/node@18.0.0)(typescript@4.7.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -3438,7 +3451,7 @@ packages:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -3455,7 +3468,7 @@ packages:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
     dev: true
@@ -3471,7 +3484,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.6
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -3522,7 +3535,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
       jest-util: 29.7.0
     dev: true
 
@@ -3577,7 +3590,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -3608,7 +3621,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
       chalk: 4.1.2
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
@@ -3650,7 +3663,7 @@ packages:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.5.2
+      semver: 7.6.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3660,7 +3673,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -3685,7 +3698,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -3697,13 +3710,13 @@ packages:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
 
-  /jest@29.7.0(@types/node@20.1.2)(ts-node@10.9.2):
+  /jest@29.7.0(@types/node@18.0.0)(ts-node@10.9.2):
     resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -3716,7 +3729,7 @@ packages:
       '@jest/core': 29.7.0(ts-node@10.9.2)
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.1.2)(ts-node@10.9.2)
+      jest-cli: 29.7.0(@types/node@18.0.0)(ts-node@10.9.2)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -3932,7 +3945,7 @@ packages:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
     dependencies:
-      semver: 7.5.2
+      semver: 7.6.0
     dev: true
 
   /make-error@1.3.6:
@@ -4108,7 +4121,7 @@ packages:
     dependencies:
       hosted-git-info: 2.8.9
       resolve: 1.22.2
-      semver: 7.5.2
+      semver: 7.6.0
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -4616,8 +4629,8 @@ packages:
       xmlchars: 2.2.0
     dev: true
 
-  /semver@7.5.2:
-    resolution: {integrity: sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==}
+  /semver@7.6.0:
+    resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -5009,17 +5022,17 @@ packages:
       '@babel/core': 7.21.8
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.1.2)(ts-node@10.9.2)
+      jest: 29.7.0(@types/node@18.0.0)(ts-node@10.9.2)
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.5.2
+      semver: 7.6.0
       typescript: 4.7.2
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-node@10.9.2(@types/node@20.1.2)(typescript@4.7.2):
+  /ts-node@10.9.2(@types/node@18.0.0)(typescript@4.7.2):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
@@ -5038,7 +5051,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 20.1.2
+      '@types/node': 18.0.0
       acorn: 8.8.2
       acorn-walk: 8.3.2
       arg: 4.1.3

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1,5 +1,6 @@
 import 'whatwg-fetch'
 
+import semver from 'semver'
 import { server } from './mocks/server'
 import { ApiError, arrayRequestBody, Fetcher } from '../src'
 import { Data, paths } from './paths'
@@ -111,25 +112,27 @@ describe('fetch', () => {
     expect(data.headers).not.toHaveProperty('content-type')
   })
 
-  it('POST /body/{id} (bigint)', async () => {
-    const fun = fetcher.path('/body/{id}').method('post').create()
+  if (semver.satisfies(process.versions.node, '>=21')) {
+    it('POST /body/{id} (bigint)', async () => {
+      const fun = fetcher.path('/body/{id}').method('post').create()
 
-    const safeInteger = Number.MAX_SAFE_INTEGER
-    const tooBigForNumber = BigInt(String(safeInteger + 2))
-    // transforms to BigInt as it exceeds the limit
-    const result1 = await fun({ id: 1, bigInt: tooBigForNumber })
-    expect(result1.data.body).toEqual({ bigInt: tooBigForNumber })
-    // way too big for number
-    const wayTooBig = BigInt('1' + '0'.repeat(20))
-    const result2 = await fun({ id: 1, bigInt: wayTooBig })
-    expect(result2.data.body).toEqual({ bigInt: wayTooBig })
-    // keeps it as safe integer as it does not exceed the limit
-    const result3 = await fun({ id: 1, bigInt: BigInt(safeInteger) })
-    expect(result3.data.body).toEqual({ bigInt: safeInteger })
-    // does not influence floats
-    const result4 = await fun({ id: 1, bigInt: 0.9007199254740991 })
-    expect(result4.data.body).toEqual({ bigInt: 0.9007199254740991 })
-  })
+      const safeInteger = Number.MAX_SAFE_INTEGER
+      const tooBigForNumber = BigInt(String(safeInteger + 2))
+      // transforms to BigInt as it exceeds the limit
+      const result1 = await fun({ id: 1, bigInt: tooBigForNumber })
+      expect(result1.data.body).toEqual({ bigInt: tooBigForNumber })
+      // way too big for number
+      const wayTooBig = BigInt('1' + '0'.repeat(20))
+      const result2 = await fun({ id: 1, bigInt: wayTooBig })
+      expect(result2.data.body).toEqual({ bigInt: wayTooBig })
+      // keeps it as safe integer as it does not exceed the limit
+      const result3 = await fun({ id: 1, bigInt: BigInt(safeInteger) })
+      expect(result3.data.body).toEqual({ bigInt: safeInteger })
+      // does not influence floats
+      const result4 = await fun({ id: 1, bigInt: 0.9007199254740991 })
+      expect(result4.data.body).toEqual({ bigInt: 0.9007199254740991 })
+    })
+  }
 
   it(`POST /accepted`, async () => {
     const fun = fetcher.path('/accepted').method('post').create({})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "outDir": "./dist/esm"
+        "outDir": "./dist/esm",
+        "types": ["node", "jest"]
     },
     "extends": "./tsconfig.base.json"
 }


### PR DESCRIPTION
This returns Node.18 compatibility and only tests BigInt support if the detected version is Node >= 21